### PR TITLE
Queue campaign SMS jobs in background

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -60,6 +60,8 @@ Yes. OTP verification for WordPress and WooCommerce registration and login works
 == Changelog ==
 
 = 1.0.12 =
+* Added a background processor so campaign SMS messages are queued individually and sent by scheduled jobs.
+* Aggregated campaign job results into concise admin notices that highlight failed numbers and the most recent error.
 * Simplified OTP storage to rely solely on WordPress transients instead of WooCommerce sessions.
 
 = 1.0.11 =

--- a/admin/class-alpha_sms-admin.php
+++ b/admin/class-alpha_sms-admin.php
@@ -417,10 +417,6 @@ class Alpha_sms_Admin
             $this->add_flash_notice(esc_html($message), 'error');
         }
 
-        if (0 === $queued && empty($failedQueue)) {
-            $this->add_flash_notice(__("No SMS messages were queued.", $this->plugin_name), "error");
-        }
-
         // Redirect to plugin page
         wp_redirect($_SERVER['HTTP_REFERER']);
         exit();

--- a/admin/class-alpha_sms-admin.php
+++ b/admin/class-alpha_sms-admin.php
@@ -85,7 +85,7 @@ class Alpha_sms_Admin
      */
     private function get_background_processor()
     {
-        if ($this->background && class_exists('Alpha_SMS_Background') && $this->background instanceof Alpha_SMS_Background) {
+        if ($this->background instanceof Alpha_SMS_Background) {
             return $this->background;
         }
 

--- a/admin/class-alpha_sms-admin.php
+++ b/admin/class-alpha_sms-admin.php
@@ -54,8 +54,9 @@ class Alpha_sms_Admin
     /**
      * Initialize the class and set its properties.
      *
-     * @param string $plugin_name The name of this plugin.
-     * @param string $version The version of this plugin.
+     * @param string                    $plugin_name The name of this plugin.
+     * @param string                    $version     The version of this plugin.
+     * @param Alpha_SMS_Background|null $background  Optional background processor instance.
      * @since    1.0.0
      */
     public function __construct($plugin_name, $version, $background = null)
@@ -334,14 +335,14 @@ class Alpha_sms_Admin
             $this->add_flash_notice(__("Fill the required fields properly", $this->plugin_name), "error");
 
             // Redirect to plugin page
-            wp_redirect($_SERVER['HTTP_REFERER']);
+            wp_safe_redirect(wp_get_referer());
             exit();
         }
         if (!$api_key) {
             $this->add_flash_notice(__("No valid API Key is set.", $this->plugin_name), "error");
 
             // Redirect to plugin page
-            wp_redirect($_SERVER['HTTP_REFERER']);
+            wp_safe_redirect(wp_get_referer());
             exit();
         }
 
@@ -363,7 +364,7 @@ class Alpha_sms_Admin
             $this->add_flash_notice(__("No valid recipients were provided.", $this->plugin_name), "error");
 
             // Redirect to plugin page
-            wp_redirect($_SERVER['HTTP_REFERER']);
+            wp_safe_redirect(wp_get_referer());
             exit();
         }
 
@@ -374,7 +375,7 @@ class Alpha_sms_Admin
                 "error");
 
             // Redirect to plugin page
-            wp_redirect($_SERVER['HTTP_REFERER']);
+            wp_safe_redirect(wp_get_referer());
             exit();
         }
 
@@ -418,7 +419,7 @@ class Alpha_sms_Admin
         }
 
         // Redirect to plugin page
-        wp_redirect($_SERVER['HTTP_REFERER']);
+        wp_safe_redirect(wp_get_referer());
         exit();
     }
 
@@ -509,13 +510,18 @@ class Alpha_sms_Admin
                 foreach ($results['failures'] as $failure) {
                     $number = isset($failure['number']) ? $failure['number'] : '';
                     $message = isset($failure['message']) ? $failure['message'] : '';
-                    $detail = trim($number);
+
+                    $detail_parts = [];
+                    $trimmed_number = trim($number);
+                    if ($trimmed_number !== '') {
+                        $detail_parts[] = $trimmed_number;
+                    }
                     if ($message !== '') {
-                        $detail .= $detail ? ' - ' . $message : $message;
+                        $detail_parts[] = $message;
                     }
 
-                    if ($detail !== '') {
-                        $details[] = $detail;
+                    if (!empty($detail_parts)) {
+                        $details[] = implode(' - ', $detail_parts);
                     }
                 }
 

--- a/admin/class-alpha_sms-admin.php
+++ b/admin/class-alpha_sms-admin.php
@@ -45,17 +45,51 @@ class Alpha_sms_Admin
     private $version;
 
     /**
+     * Background processor for queued SMS jobs.
+     *
+     * @var Alpha_SMS_Background|null
+     */
+    private $background;
+
+    /**
      * Initialize the class and set its properties.
      *
      * @param string $plugin_name The name of this plugin.
      * @param string $version The version of this plugin.
      * @since    1.0.0
      */
-    public function __construct($plugin_name, $version)
+    public function __construct($plugin_name, $version, $background = null)
     {
 
         $this->plugin_name = $plugin_name;
         $this->version = $version;
+        $this->background = $background;
+    }
+
+    /**
+     * Set the background processor instance.
+     *
+     * @param Alpha_SMS_Background|null $background Background processor.
+     *
+     * @return void
+     */
+    public function set_background_processor($background)
+    {
+        $this->background = $background;
+    }
+
+    /**
+     * Retrieve the background processor instance.
+     *
+     * @return Alpha_SMS_Background|null
+     */
+    private function get_background_processor()
+    {
+        if ($this->background && class_exists('Alpha_SMS_Background') && $this->background instanceof Alpha_SMS_Background) {
+            return $this->background;
+        }
+
+        return null;
     }
 
     /**
@@ -321,26 +355,70 @@ class Alpha_sms_Admin
             $numbersArr = array_merge($numbersArr, $woo_numbers);
         }
 
-        // Final Numbers
-        $numbers = implode(',', $numbersArr);
+        $numbersArr = array_map('trim', $numbersArr);
+        $numbersArr = array_filter($numbersArr);
+        $numbersArr = array_unique($numbersArr);
 
-        require_once ALPHA_SMS_PATH . 'includes/sms.class.php';
+        if (empty($numbersArr)) {
+            $this->add_flash_notice(__("No valid recipients were provided.", $this->plugin_name), "error");
 
-        $sms = new AlphaSMS($api_key);
-        $sms->numbers = $numbers;
-        $sms->body = $body;
-        $sms->sender_id = $sender_id;
+            // Redirect to plugin page
+            wp_redirect($_SERVER['HTTP_REFERER']);
+            exit();
+        }
 
-        $response = $sms->Send();
+        $background = $this->get_background_processor();
 
-        if (!$response) {
-            $this->add_flash_notice(__("Something went wrong, please try again.", $this->plugin_name), "error");
+        if (!$background) {
+            $this->add_flash_notice(__("Background processing is unavailable. Please try again later.", $this->plugin_name),
+                "error");
 
-        } elseif ($response->error !== 0) {
-            $this->add_flash_notice(__($response->msg), 'error');
+            // Redirect to plugin page
+            wp_redirect($_SERVER['HTTP_REFERER']);
+            exit();
+        }
 
-        } else {
-            $this->add_flash_notice(__($response->msg), 'success');
+        $queued = 0;
+        $failedQueue = [];
+
+        foreach ($numbersArr as $number) {
+            if ($background->dispatch($number, $body, $sender_id, $api_key)) {
+                $queued++;
+            } else {
+                $failedQueue[] = $number;
+            }
+        }
+
+        if ($queued > 0) {
+            $notice = sprintf(
+                _n('Queued %d SMS message for background sending.', 'Queued %d SMS messages for background sending.', $queued,
+                    $this->plugin_name),
+                $queued
+            );
+            $this->add_flash_notice(esc_html($notice), 'success');
+        }
+
+        if (!empty($failedQueue)) {
+            $failedQueue = array_map('sanitize_text_field', $failedQueue);
+            $preview = array_slice($failedQueue, 0, 5);
+            $summary = implode(', ', $preview);
+            if ('' === trim($summary)) {
+                $summary = __('unknown recipients', $this->plugin_name);
+            }
+            $message = sprintf(
+                __('Unable to queue %1$d recipient(s): %2$s', $this->plugin_name),
+                count($failedQueue),
+                $summary
+            );
+            if (count($failedQueue) > count($preview)) {
+                $message .= ' ' . sprintf(__('and %d more.', $this->plugin_name), count($failedQueue) - count($preview));
+            }
+
+            $this->add_flash_notice(esc_html($message), 'error');
+        }
+
+        if (0 === $queued && empty($failedQueue)) {
+            $this->add_flash_notice(__("No SMS messages were queued.", $this->plugin_name), "error");
         }
 
         // Redirect to plugin page
@@ -391,6 +469,75 @@ class Alpha_sms_Admin
     }
 
     /**
+     * Persist job results as flash notices for display in the admin area.
+     *
+     * @return void
+     */
+    private function maybe_add_job_result_notice()
+    {
+        $results = get_option($this->plugin_name . '_job_results', []);
+
+        if (empty($results) || !is_array($results)) {
+            return;
+        }
+
+        $defaults = [
+            'success'    => 0,
+            'failed'     => 0,
+            'last_error' => '',
+            'failures'   => [],
+        ];
+
+        $results = wp_parse_args($results, $defaults);
+
+        if (!empty($results['success'])) {
+            $success_notice = sprintf(
+                _n('%d SMS message was sent successfully.', '%d SMS messages were sent successfully.', (int)$results['success'],
+                    $this->plugin_name),
+                (int)$results['success']
+            );
+            $this->add_flash_notice(esc_html($success_notice), 'success');
+        }
+
+        if (!empty($results['failed'])) {
+            $error_notice = sprintf(
+                _n('%d SMS message failed to send.', '%d SMS messages failed to send.', (int)$results['failed'],
+                    $this->plugin_name),
+                (int)$results['failed']
+            );
+
+            if (!empty($results['last_error'])) {
+                $error_notice .= ' ' . sprintf(__('Last error: %s', $this->plugin_name), $results['last_error']);
+            } elseif (!empty($results['failures']) && is_array($results['failures'])) {
+                $details = [];
+                foreach ($results['failures'] as $failure) {
+                    $number = isset($failure['number']) ? $failure['number'] : '';
+                    $message = isset($failure['message']) ? $failure['message'] : '';
+                    $detail = trim($number);
+                    if ($message !== '') {
+                        $detail .= $detail ? ' - ' . $message : $message;
+                    }
+
+                    if ($detail !== '') {
+                        $details[] = $detail;
+                    }
+                }
+
+                if (!empty($details)) {
+                    $error_notice .= ' ' . sprintf(
+                        _n('Latest error: %s', 'Latest errors: %s', count($details), $this->plugin_name),
+                        implode('; ', $details)
+                    );
+                }
+            }
+
+            $this->add_flash_notice(esc_html($error_notice), 'error');
+        }
+
+        delete_option($this->plugin_name . '_job_results');
+    }
+
+    /**
      * Function executed when the 'admin_notices' action is called, here we check if there are notices on
      * our database and display them, after that, we remove the option to prevent notices being displayed forever.
      * @return void
@@ -398,6 +545,8 @@ class Alpha_sms_Admin
 
     public function display_flash_notices()
     {
+        $this->maybe_add_job_result_notice();
+
         $notices = get_option($this->plugin_name . '_notices', []);
 
         // Iterate through our notices to be displayed and print them.

--- a/includes/class-alpha_sms-background.php
+++ b/includes/class-alpha_sms-background.php
@@ -13,6 +13,7 @@ if (!defined('WPINC')) {
  *
  * @package    Alpha_sms
  * @subpackage Alpha_sms/includes
+ * @since      1.0.12 Introduced to queue individual SMS jobs for campaign sending.
  */
 class Alpha_SMS_Background
 {
@@ -40,6 +41,8 @@ class Alpha_SMS_Background
 
     /**
      * Queue a single SMS job.
+     *
+     * @since 1.0.12
      *
      * @param string $number    Recipient phone number.
      * @param string $body      Message body.
@@ -79,6 +82,8 @@ class Alpha_SMS_Background
 
     /**
      * Process a queued SMS job.
+     *
+     * @since 1.0.12
      *
      * @param array $payload Job payload data.
      *
@@ -125,6 +130,8 @@ class Alpha_SMS_Background
 
     /**
      * Store job results for later display in the admin area.
+     *
+     * @since 1.0.12
      *
      * @param array $payload  Job payload data.
      * @param mixed $response Response from the API.
@@ -185,6 +192,8 @@ class Alpha_SMS_Background
     /**
      * Determine if the API response indicates a successful send.
      *
+     * @since 1.0.12
+     *
      * @param mixed $response Response data.
      *
      * @return bool
@@ -209,6 +218,8 @@ class Alpha_SMS_Background
     /**
      * Extract an error message from the response.
      *
+     * @since 1.0.12
+     *
      * @param mixed $response Response data.
      *
      * @return string
@@ -230,6 +241,8 @@ class Alpha_SMS_Background
 
     /**
      * Normalize a phone number string.
+     *
+     * @since 1.0.12
      *
      * @param string $number Raw phone number input.
      *

--- a/includes/class-alpha_sms-background.php
+++ b/includes/class-alpha_sms-background.php
@@ -1,0 +1,232 @@
+<?php
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+/**
+ * Handle background SMS sending jobs.
+ *
+ * This class is responsible for dispatching background jobs using
+ * wp_schedule_single_event() and processing the payload for each
+ * scheduled job.
+ *
+ * @package    Alpha_sms
+ * @subpackage Alpha_sms/includes
+ */
+class Alpha_SMS_Background
+{
+    /**
+     * Action hook used to process a single SMS job.
+     */
+    public const ACTION_HOOK = 'alpha_sms_send_single_sms';
+
+    /**
+     * Plugin slug/text domain.
+     *
+     * @var string
+     */
+    protected $plugin_name;
+
+    /**
+     * Constructor.
+     *
+     * @param string $plugin_name Plugin slug/text domain.
+     */
+    public function __construct($plugin_name)
+    {
+        $this->plugin_name = $plugin_name;
+    }
+
+    /**
+     * Queue a single SMS job.
+     *
+     * @param string $number    Recipient phone number.
+     * @param string $body      Message body.
+     * @param string $sender_id Sender ID (optional).
+     * @param string $api_key   API key used to authenticate requests.
+     *
+     * @return bool Whether the job was queued successfully.
+     */
+    public function dispatch($number, $body, $sender_id, $api_key)
+    {
+        if (!function_exists('wp_schedule_single_event')) {
+            return false;
+        }
+
+        $number = $this->normalize_number($number);
+        $body = is_string($body) ? trim($body) : '';
+        $sender_id = is_string($sender_id) ? trim($sender_id) : '';
+        $api_key = is_string($api_key) ? trim($api_key) : '';
+
+        if ('' === $number || '' === $body || '' === $api_key) {
+            return false;
+        }
+
+        $payload = [
+            'job_id'      => uniqid('alpha_sms_job_', true),
+            'plugin_name' => $this->plugin_name,
+            'number'      => $number,
+            'body'        => $body,
+            'sender_id'   => $sender_id,
+            'api_key'     => $api_key,
+        ];
+
+        $timestamp = time() + 1;
+
+        return false !== wp_schedule_single_event($timestamp, self::ACTION_HOOK, [$payload]);
+    }
+
+    /**
+     * Process a queued SMS job.
+     *
+     * @param array $payload Job payload data.
+     *
+     * @return void
+     */
+    public function alpha_sms_send_single_sms($payload)
+    {
+        if (!is_array($payload)) {
+            return;
+        }
+
+        $number = isset($payload['number']) ? $this->normalize_number($payload['number']) : '';
+        $body = isset($payload['body']) ? (string)$payload['body'] : '';
+        $sender_id = isset($payload['sender_id']) ? (string)$payload['sender_id'] : '';
+        $api_key = isset($payload['api_key']) ? (string)$payload['api_key'] : '';
+
+        if ('' === $number || '' === $body || '' === $api_key) {
+            return;
+        }
+
+        if (!class_exists('AlphaSMS')) {
+            require_once ALPHA_SMS_PATH . 'includes/sms.class.php';
+        }
+
+        $sms = new AlphaSMS($api_key);
+        $sms->numbers = $number;
+        $sms->body = $body;
+
+        if ('' !== $sender_id) {
+            $sms->sender_id = $sender_id;
+        }
+
+        $response = $sms->Send();
+
+        $this->record_result($payload, $response);
+    }
+
+    /**
+     * Store job results for later display in the admin area.
+     *
+     * @param array $payload  Job payload data.
+     * @param mixed $response Response from the API.
+     *
+     * @return void
+     */
+    protected function record_result($payload, $response)
+    {
+        $option_key = $this->plugin_name . '_job_results';
+
+        $results = get_option($option_key, []);
+        if (!is_array($results)) {
+            $results = [];
+        }
+
+        $defaults = [
+            'success'    => 0,
+            'failed'     => 0,
+            'last_error' => '',
+            'failures'   => [],
+        ];
+
+        $results = wp_parse_args($results, $defaults);
+
+        if ($this->is_successful_response($response)) {
+            $results['success']++;
+        } else {
+            $results['failed']++;
+
+            $message = $this->extract_error_message($response);
+            $sanitized_message = sanitize_text_field($message);
+            $results['last_error'] = $sanitized_message;
+
+            if (!is_array($results['failures'])) {
+                $results['failures'] = [];
+            }
+
+            if (count($results['failures']) < 5) {
+                $results['failures'][] = [
+                    'number'  => sanitize_text_field($this->normalize_number(isset($payload['number']) ? $payload['number'] : '')),
+                    'message' => $sanitized_message,
+                ];
+            }
+        }
+
+        update_option($option_key, $results);
+    }
+
+    /**
+     * Determine if the API response indicates a successful send.
+     *
+     * @param mixed $response Response data.
+     *
+     * @return bool
+     */
+    protected function is_successful_response($response)
+    {
+        if (is_wp_error($response)) {
+            return false;
+        }
+
+        if (is_object($response) && isset($response->error)) {
+            return (int)$response->error === 0;
+        }
+
+        if (is_array($response) && isset($response['error'])) {
+            return (int)$response['error'] === 0;
+        }
+
+        return (bool)$response;
+    }
+
+    /**
+     * Extract an error message from the response.
+     *
+     * @param mixed $response Response data.
+     *
+     * @return string
+     */
+    protected function extract_error_message($response)
+    {
+        if (is_wp_error($response)) {
+            $message = $response->get_error_message();
+        } elseif (is_object($response) && isset($response->msg)) {
+            $message = (string)$response->msg;
+        } elseif (is_array($response) && isset($response['msg'])) {
+            $message = (string)$response['msg'];
+        } else {
+            $message = __('Unknown error while sending SMS.', $this->plugin_name);
+        }
+
+        return wp_strip_all_tags($message);
+    }
+
+    /**
+     * Normalize a phone number string.
+     *
+     * @param mixed $number Raw phone number input.
+     *
+     * @return string
+     */
+    protected function normalize_number($number)
+    {
+        if (is_array($number)) {
+            $number = reset($number);
+        }
+
+        $number = trim((string)$number);
+
+        return preg_replace('/\s+/', '', $number);
+    }
+}

--- a/includes/class-alpha_sms-background.php
+++ b/includes/class-alpha_sms-background.php
@@ -90,10 +90,17 @@ class Alpha_SMS_Background
             return;
         }
 
-        $number = isset($payload['number']) ? $this->normalize_number($payload['number']) : '';
-        $body = isset($payload['body']) ? (string)$payload['body'] : '';
-        $sender_id = isset($payload['sender_id']) ? (string)$payload['sender_id'] : '';
-        $api_key = isset($payload['api_key']) ? (string)$payload['api_key'] : '';
+        $payload = wp_parse_args($payload, [
+            'number'    => '',
+            'body'      => '',
+            'sender_id' => '',
+            'api_key'   => '',
+        ]);
+
+        $number = $this->normalize_number($payload['number']);
+        $body = (string)$payload['body'];
+        $sender_id = (string)$payload['sender_id'];
+        $api_key = (string)$payload['api_key'];
 
         if ('' === $number || '' === $body || '' === $api_key) {
             return;
@@ -129,11 +136,9 @@ class Alpha_SMS_Background
         $option_key = $this->plugin_name . '_job_results';
         $lock_key = $option_key . '_lock';
 
-        if (get_transient($lock_key)) {
+        if (!add_transient($lock_key, true, 10)) {
             return;
         }
-
-        set_transient($lock_key, true, 10);
 
         try {
             $results = get_option($option_key, []);

--- a/includes/class-alpha_sms.php
+++ b/includes/class-alpha_sms.php
@@ -76,7 +76,7 @@ class Alpha_sms
         if (defined('ALPHA_SMS_VERSION')) {
             $this->version = ALPHA_SMS_VERSION;
         } else {
-            $this->version = '1.0.0';
+            $this->version = '1.0.12';
         }
         $this->plugin_name = 'alpha_sms';
 

--- a/includes/class-alpha_sms.php
+++ b/includes/class-alpha_sms.php
@@ -112,6 +112,11 @@ class Alpha_sms
         require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-alpha_sms-loader.php';
 
         /**
+         * Background processing utilities.
+         */
+        require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-alpha_sms-background.php';
+
+        /**
          * The class responsible for defining internationalization functionality
          * of the plugin.
          */
@@ -158,7 +163,10 @@ class Alpha_sms
     private function define_admin_hooks()
     {
 
-        $plugin_admin = new Alpha_sms_Admin($this->get_plugin_name(), $this->get_version());
+        $background = new Alpha_SMS_Background($this->get_plugin_name());
+        $plugin_admin = new Alpha_sms_Admin($this->get_plugin_name(), $this->get_version(), $background);
+
+        $this->loader->add_action(Alpha_SMS_Background::ACTION_HOOK, $background, 'alpha_sms_send_single_sms', 10, 1);
 
         $this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
         $this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');


### PR DESCRIPTION
## Summary
- add a background processor that schedules single-number SMS jobs and records their results
- load the background processor in the core bootstrap and register the alpha_sms_send_single_sms handler
- queue campaign numbers individually from the admin form and surface aggregated job results via notices

## Testing
- `php -l includes/class-alpha_sms-background.php`
- `php -l includes/class-alpha_sms.php`
- `php -l admin/class-alpha_sms-admin.php`


------
https://chatgpt.com/codex/tasks/task_b_68c957e74a1c832a8faedc5d0885233e