### PR TITLE
Allow WooCommerce registration OTP validation without checkout OTP

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: order notification, order SMS, woocommerce sms integration, sms plugin, mo
 Requires at least: 3.5
 Tested up to: 6.8.2
 Requires PHP: 5.6
-Stable tag: 1.0.12
+Stable tag: 1.0.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,7 +59,7 @@ Yes. OTP verification for WordPress and WooCommerce registration and login works
 
 == Changelog ==
 
-= 1.0.12 =
+= 1.0.13 =
 * Added a background processor so campaign SMS messages are queued individually and sent by scheduled jobs.
 * Aggregated campaign job results into concise admin notices that highlight failed numbers and the most recent error.
 

--- a/alpha_sms.php
+++ b/alpha_sms.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Alpha SMS
  * Plugin URI:        https://sms.net.bd/plugins/wordpress
  * Description:       WP 2FA Login. SMS OTP Verification for Registration and Login forms, WooCommerce SMS Notification for your shop orders.
- * Version:           1.0.12
+ * Version:           1.0.13
  * Author:            Alpha Net
  * Author URI:        https://sms.net.bd/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('ALPHA_SMS_VERSION', '1.0.12');
+define('ALPHA_SMS_VERSION', '1.0.13');
 
 // plugin constants
 try {

--- a/includes/class-alpha_sms.php
+++ b/includes/class-alpha_sms.php
@@ -76,7 +76,7 @@ class Alpha_sms
         if (defined('ALPHA_SMS_VERSION')) {
             $this->version = ALPHA_SMS_VERSION;
         } else {
-            $this->version = '1.0.12';
+            $this->version = '1.0.13';
         }
         $this->plugin_name = 'alpha_sms';
 

--- a/public/class-alpha_sms-public.php
+++ b/public/class-alpha_sms-public.php
@@ -595,7 +595,7 @@ class Alpha_sms_Public
                 $action_type = isset($_REQUEST['action_type']) ? sanitize_text_field($_REQUEST['action_type']) : '';
 
                 $shouldValidate = $this->pluginActive && (
-                        ($this->options['otp_checkout'] && !$enable_guest_checkout) ||
+                        (!empty($this->options['otp_checkout']) && !$enable_guest_checkout) ||
                         (!empty($this->options['wc_reg']) && $action_type === 'wc_reg') ||
                         (!empty($this->options['wp_reg']) && $action_type === 'wp_reg')
                 );

--- a/public/class-alpha_sms-public.php
+++ b/public/class-alpha_sms-public.php
@@ -589,12 +589,20 @@ class Alpha_sms_Public
 	public function register_form_validation($errors, $sanitized_user_login, $user_email)
 	{
 
-		$enable_guest_checkout = get_option('woocommerce_enable_guest_checkout');
-		$enable_guest_checkout = $enable_guest_checkout === 'yes' ? true : false;
+                $enable_guest_checkout = get_option('woocommerce_enable_guest_checkout');
+                $enable_guest_checkout = $enable_guest_checkout === 'yes' ? true : false;
 
-		if (!$this->pluginActive || !$this->options['otp_checkout'] || $enable_guest_checkout) {
-			return $errors;
-		}
+                $action_type = isset($_REQUEST['action_type']) ? sanitize_text_field($_REQUEST['action_type']) : '';
+
+                $shouldValidate = $this->pluginActive && (
+                        ($this->options['otp_checkout'] && !$enable_guest_checkout) ||
+                        (!empty($this->options['wc_reg']) && $action_type === 'wc_reg') ||
+                        (!empty($this->options['wp_reg']) && $action_type === 'wp_reg')
+                );
+
+                if (!$shouldValidate) {
+                        return $errors;
+                }
 
 		if (
 			empty($_REQUEST['billing_phone']) || !is_numeric($_REQUEST['billing_phone']) ||


### PR DESCRIPTION
## Summary
- ensure register_form_validation runs for WooCommerce registration OTP requests even when checkout OTP is disabled
- retain shared validation logic by checking the incoming action type before returning early

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6906db3c5d80832a97c874d3a45852c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation to correctly skip or run checks depending on registration flow and account/checkout settings.

* **Refactor**
  * Reworked registration validation gating so validation executes only when appropriate for the detected registration path and configuration.

* **Chores**
  * Bumped plugin version and updated release metadata to 1.0.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->