### PR TITLE
Set plugin version to 1.0.13

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: order notification, order SMS, woocommerce sms integration, sms plugin, mo
 Requires at least: 3.5
 Tested up to: 6.8.2
 Requires PHP: 5.6
-Stable tag: 1.0.12
+Stable tag: 1.0.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,7 +59,7 @@ Yes. OTP verification for WordPress and WooCommerce registration and login works
 
 == Changelog ==
 
-= 1.0.12 =
+= 1.0.13 =
 * Added a background processor so campaign SMS messages are queued individually and sent by scheduled jobs.
 * Aggregated campaign job results into concise admin notices that highlight failed numbers and the most recent error.
 

--- a/alpha_sms.php
+++ b/alpha_sms.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Alpha SMS
  * Plugin URI:        https://sms.net.bd/plugins/wordpress
  * Description:       WP 2FA Login. SMS OTP Verification for Registration and Login forms, WooCommerce SMS Notification for your shop orders.
- * Version:           1.0.12
+ * Version:           1.0.13
  * Author:            Alpha Net
  * Author URI:        https://sms.net.bd/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('ALPHA_SMS_VERSION', '1.0.12');
+define('ALPHA_SMS_VERSION', '1.0.13');
 
 // plugin constants
 try {

--- a/includes/class-alpha_sms.php
+++ b/includes/class-alpha_sms.php
@@ -76,7 +76,7 @@ class Alpha_sms
         if (defined('ALPHA_SMS_VERSION')) {
             $this->version = ALPHA_SMS_VERSION;
         } else {
-            $this->version = '1.0.12';
+            $this->version = '1.0.13';
         }
         $this->plugin_name = 'alpha_sms';
 


### PR DESCRIPTION
## Summary
- revert the plugin header and version constant to 1.0.13
- align the readme stable tag and changelog heading with version 1.0.13

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6906e803ffd0832a98c2bc9c071a00b9